### PR TITLE
fix a type error in blending backgrounds

### DIFF
--- a/lua/monokai-pro/config.lua
+++ b/lua/monokai-pro/config.lua
@@ -36,7 +36,7 @@ local default = {
 }
 
 ---@type Config
-M.options = {}
+M.options = default
 
 ---@param options Config|nil
 M.setup = function(options)

--- a/lua/monokai-pro/theme/editor.lua
+++ b/lua/monokai-pro/theme/editor.lua
@@ -110,7 +110,7 @@ M.setup = function(c, config, hp)
 			fg = c.editorSuggestWidget.foreground,
 		}, -- Popup menu: normal item.
 		PmenuSel = cmpBackgroundClear and {
-			bg = hp.blend(c.editorSuggestWidget.selectedBackground, c.editor.background, 0.7),
+			bg = hp.blend(c.editorSuggestWidget.selectedBackground, 0.7, c.editor.background),
 		} or {
 			bg = c.editorSuggestWidget.selectedBackground,
 		},


### PR DESCRIPTION
The call to blend() in editor.lua got the order of parameters wrong, resulting in a type error.