### PR TITLE
General life improvements

### DIFF
--- a/lua/monokai-pro/theme/editor.lua
+++ b/lua/monokai-pro/theme/editor.lua
@@ -184,7 +184,7 @@ M.setup = function(c, config, hp)
       fg = c.base.black,
     }, -- the column separating windows
     Whitespace = {
-      fg = c.editor.background,
+      fg = c.base.dimmed4,
     }, -- "nbsp", "space", "tab" and "trail" in 'listchars'
     -- WildMenu = { bg = C.blue, fg = C.black }, -- current match in 'wildmenu' completion
 

--- a/lua/monokai-pro/theme/editor.lua
+++ b/lua/monokai-pro/theme/editor.lua
@@ -161,16 +161,11 @@ M.setup = function(c, config, hp)
       underline = false,
       bold = true,
     }, -- 'incsearch' highlighting; also used for the text replaced with ":s///c"
-    -- StatusLine = { bg = config.options.transparency and nil or theme.palette.bg, fg = theme.palette.fg, style = "bold" }, -- status line of current window
-    -- StatusLineNC = {
-    --     bg = config.options.transparency andnil
-    --         or config.options.window_unfocused_color and theme.generated.color_column
-    --         or theme.palette.bg,
-    --     fg = theme.palette.fg,
-    -- }, -- status lines of not-current windows Note: if this is equal to "StatusLine" Vim will use "^^^" in the status line of the current window.
-    -- TabLine = { bg = config.options.transparency and nil or theme.palette.bg }, -- tab pages line, not active tab page label
-    -- TabLineFill = { bg = config.options.transparency and nil or theme.palette.bg, fg = theme.palette.fg }, -- tab pages line, where there are no labels
-    -- TabLineSel = { bg = theme.palette.purple, fg = theme.palette.bg }, -- tab pages line, active tab page label
+    StatusLine = { bg = c.statusBar.background, fg = c.editor.foreground, },
+    StatusLineNC = { bg = c.statusBar.background, fg = c.statusBar.foreground, },
+    TabLine = { link = "StatuslineNC", },
+    TabLineFill = { link = "StatusLineNC", },
+    TabLineSel = { bg = c.editor.background, fg = c.editor.foreground, },
     -- TermCursorNC = { bg = C.gray }, -- cursor in an unfocused terminal
     Title = {
       fg = c.base.yellow,


### PR DESCRIPTION
Hi,
Loving the colorscheme so far but there are some pain points for me.
This PR makes the following changes:
* Provides default statusline and tabline highlights
* Changes the default white character color to something visible and that doesn't collide with the comment highlight

> NOTE
> The screenshots where made with the 'classic' palette, but I've tested with the other variants

## StatusLine

*before*
![Screenshot 2023-02-11 at 11 41 39](https://user-images.githubusercontent.com/96259932/218254216-9d48561d-ba90-4b52-998d-a103bd631fe6.png)

*after*
![Screenshot 2023-02-11 at 11 41 53](https://user-images.githubusercontent.com/96259932/218254220-b6b2632a-b58c-493f-accb-48d1705b6976.png)

## Tabline

*before*
![Screenshot 2023-02-11 at 11 42 05](https://user-images.githubusercontent.com/96259932/218254245-fa55b607-11f0-4e2c-88c8-986122181586.png)

*after*
![Screenshot 2023-02-11 at 11 42 17](https://user-images.githubusercontent.com/96259932/218254259-87a28d32-44f2-4001-9eef-4077574d2c74.png)

## Whitespaces

*before*
![Screenshot 2023-02-11 at 11 38 17](https://user-images.githubusercontent.com/96259932/218254278-8fcb8b18-063d-4210-aa88-cf50d578217b.png)

*after*
![Screenshot 2023-02-11 at 11 38 40](https://user-images.githubusercontent.com/96259932/218254285-a80a94f5-72f2-4d3e-a34e-2b806da7a786.png)

