### PR TITLE
feat(ts-rainbow2): add plugin support

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ Find out more here [monokai.pro](https://monokai.pro/)
 - [barbecue.nvim](https://github.com/utilyre/barbecue.nvim)
 - [dashboard-nvim](https://github.com/glepnir/dashboard-nvim)
 - [mason.nvim](https://github.com/williamboman/mason.nvim)
+- [nvim-ts-rainbow2](https://github.com/HiPhish/nvim-ts-rainbow2)
 
 ## 📦 Installation
 

--- a/lua/monokai-pro/theme/init.lua
+++ b/lua/monokai-pro/theme/init.lua
@@ -23,6 +23,7 @@ local plugins = {
   "nvim-navic",
   "nvim-tree",
   "nvim-treesitter",
+  "nvim-ts-rainbow2",
   "packer",
   "renamer",
   "scrollbar",

--- a/lua/monokai-pro/theme/plugins/nvim-ts-rainbow2.lua
+++ b/lua/monokai-pro/theme/plugins/nvim-ts-rainbow2.lua
@@ -1,0 +1,16 @@
+local M = {}
+
+--- @param c Colorscheme The color palette
+M.setup = function(c, _, _)
+  return {
+    TSRainbowRed = { fg = c.base.red },
+    TSRainbowYellow = { fg = c.base.yellow },
+    TSRainbowBlue = { fg = c.base.cyan },
+    TSRainbowOrange = { fg = c.base.blue },
+    TSRainbowGreen = { fg = c.base.green },
+    TSRainbowViolet = { fg = c.base.magenta },
+    TSRainbowCyan = { fg = c.base.cyan },
+  }
+end
+
+return M


### PR DESCRIPTION
This PR adds support for the [nvim-ts-rainbow2](https://github.com/HiPhish/nvim-ts-rainbow2) plugin, which makes the rainbow parentheses use the Monokai Pro theme colors.

![image](https://github.com/loctvl842/monokai-pro.nvim/assets/57580593/962acf75-75e8-4abb-8276-4a49f595191e)

By the way, thank you so much for creating this theme! It looks absolutely amazing :heart: