### PR TITLE
Add lualine terminal mode color.

### DIFF
--- a/lua/lualine/themes/monokai-pro.lua
+++ b/lua/lualine/themes/monokai-pro.lua
@@ -20,6 +20,11 @@ monokai_pro.insert = {
   b = { bg = colors.base.dimmed5, fg = colors.base.green },
 }
 
+monokai_pro.terminal = {
+  a = { bg = colors.base.cyan, fg = colors.base.black },
+  b = { bg = colors.base.dimmed5, fg = colors.base.cyan },
+}
+
 monokai_pro.command = {
   a = { bg = colors.base.yellow, fg = colors.base.black },
   b = { bg = colors.base.dimmed5, fg = colors.base.yellow },


### PR DESCRIPTION
I use cyan because it's similar to green for insert, since both mode are used for accepting input.
![Screenshot 2023-09-05 at 09 42 08](https://github.com/loctvl842/monokai-pro.nvim/assets/12573521/c5c5a4fe-2a31-492b-8a55-549389a1c876)
