### PR TITLE
Add traceback to log message when plugins fail to load

### DIFF
--- a/lua/monokai-pro/theme/init.lua
+++ b/lua/monokai-pro/theme/init.lua
@@ -58,12 +58,8 @@ local function get_hl_group_tbl(colorscheme)
   local hl_group_tbl = {}
   hl_group_tbl = vim.tbl_deep_extend("force", hl_group_tbl, editor, syntax, semantic_tokens, extra)
   for _, name in ipairs(PLUGINS) do
-    local config_ok, plugin = pcall(require, "monokai-pro.theme.plugins." .. name)
-    if not config_ok then
-      local msg = "Failed to load highlight group: " .. name
-      local level = "error"
-      Util.log(msg, level)
-    else
+    local config_ok, plugin = xpcall(require, function(...) Util.log("Failed to load highlight group: " .. name .. "\n" .. debug.traceback(...), "error")return ... end, "monokai-pro.theme.plugins." .. name)
+    if config_ok then
       hl_group_tbl = vim.tbl_deep_extend("force", hl_group_tbl, plugin.setup(colorscheme, Config, Helper))
     end
   end


### PR DESCRIPTION
This allows for the traceback to be bubbled up so that people know why a plugin is failing to load.