### PR TITLE
Remove nvim-web-devicons prompt from startup

### DIFF
--- a/lua/monokai-pro/util.lua
+++ b/lua/monokai-pro/util.lua
@@ -188,7 +188,6 @@ end
 function M.get_devicon(filename, extension)
   local icon_ok, webDevicons = pcall(require, "nvim-web-devicons")
   if not icon_ok then
-    M.log("It is recommended to install 'nvim-web-devicons' for better experience.", "info")
     return
   end
   local _, icon_hl_name = webDevicons.get_icon(filename, extension, { default = true })


### PR DESCRIPTION
When `devicons = false` is explicitly set in setup config, the user is faced with a log prompting them to enable this setting upon startup, with no option to silence it.