### PR TITLE
Add usable definitions for mini.statusline colors

### DIFF
--- a/lua/monokai-pro/theme/plugins/mini.lua
+++ b/lua/monokai-pro/theme/plugins/mini.lua
@@ -5,6 +5,14 @@ local M = {}
 function M.get(c, _, _)
   return {
     MiniIndentscopeSymbol = { fg = c.base.blue },
+
+    -- mini.status
+    MiniStatuslineModeNormal = { fg = c.base.black, bg = c.base.green },
+    MiniStatuslineModeInsert = { fg = c.base.black, bg = c.base.yellow },
+    MiniStatuslineModeCommand = { fg = c.base.black, bg = c.base.red },
+    MiniStatuslineModeVisual = { fg = c.base.black, bg = c.base.cyan },
+    MiniStatuslineModeReplace = { fg = c.base.black, bg = c.base.cyan },
+    MiniStatuslineModeOther = { fg = c.base.black, bg = c.base.white },
   }
 end
 

--- a/lua/monokai-pro/theme/plugins/mini.lua
+++ b/lua/monokai-pro/theme/plugins/mini.lua
@@ -11,7 +11,7 @@ function M.get(c, _, _)
     MiniStatuslineModeInsert = { fg = c.base.black, bg = c.base.yellow },
     MiniStatuslineModeCommand = { fg = c.base.black, bg = c.base.red },
     MiniStatuslineModeVisual = { fg = c.base.black, bg = c.base.cyan },
-    MiniStatuslineModeReplace = { fg = c.base.black, bg = c.base.cyan },
+    MiniStatuslineModeReplace = { fg = c.base.black, bg = c.base.blue },
     MiniStatuslineModeOther = { fg = c.base.black, bg = c.base.white },
   }
 end


### PR DESCRIPTION
Default colors when using mini.statusline are broken at the moment, so this adds some reasonable colors.

Current (Normal mode):
![image](https://github.com/user-attachments/assets/e99d390b-0cb1-4370-b0a3-d008aba9cde5)
(bad)

New:
![image](https://github.com/user-attachments/assets/3eae6f44-743d-41af-b75c-243a3b473fde)
![image](https://github.com/user-attachments/assets/0c2e66b0-9d9f-4a69-8ff9-9724a341af08)
![image](https://github.com/user-attachments/assets/14525a86-3d76-424c-92c4-1dce56f9aa79)
![image](https://github.com/user-attachments/assets/e5260ce2-6ac5-469f-8531-3552765b6294)
![image](https://github.com/user-attachments/assets/e1d01dd3-9aaa-4358-97af-c2fdea1d6745)
