### PR TITLE
Feat: light theme

### DIFF
--- a/colors/monokai-pro-light.lua
+++ b/colors/monokai-pro-light.lua
@@ -1,0 +1,1 @@
+require("monokai-pro")._load("light")

--- a/lua/monokai-pro/colorscheme/init.lua
+++ b/lua/monokai-pro/colorscheme/init.lua
@@ -25,10 +25,10 @@ local hp = require("monokai-pro.color_helper")
 ---@param filter Filter
 ---@return ColorschemeOptions
 M.get = function(filter)
-  local filters = { "classic", "machine", "octagon", "pro", "ristretto", "spectrum" }
+  local filters = { "light", "classic", "machine", "octagon", "pro", "ristretto", "spectrum" }
 
   if not vim.tbl_contains(filters, filter) then
-    local msg = 'Invalid filter, expected "classic", "machine", "octagon", "pro", "ristretto" or "spectrum"'
+    local msg = 'Invalid filter, expected  "light", "classic", "machine", "octagon", "pro", "ristretto" or "spectrum"'
     local level = "info"
     filter = "pro"
     Util.log(msg, level)

--- a/lua/monokai-pro/colorscheme/palette/light.lua
+++ b/lua/monokai-pro/colorscheme/palette/light.lua
@@ -1,0 +1,20 @@
+---@type Palette
+return {
+  dark2 = "#d3cdcc",
+  dark1 = "#ede7e5",
+  background = "#faf4f2",
+  text = "#29242a",
+  accent1 = "#e14775",
+  accent2 = "#e16032",
+  accent3 = "#cc7a0a",
+  accent4 = "#269d69",
+  accent5 = "#1c8ca8",
+  accent6 = "#7058be",
+  dimmed1 = "#706b6e",
+  dimmed2 = "#918c8e",
+  dimmed3 = "#a59fa0",
+  dimmed4 = "#bfb9ba",
+  dimmed5 = "#d3cdcc",
+  panel = "#fefaf9",
+  light = "#ffffff",
+}

--- a/lua/monokai-pro/command.lua
+++ b/lua/monokai-pro/command.lua
@@ -9,9 +9,10 @@ M.create_filter_command = function()
   cmd("MonokaiProSelect", function()
     local menu = util.ui.create_menu("Set monokai filter", {
       "classic",
+      "light",
+      "machine",
       "octagon",
       "pro",
-      "machine",
       "ristretto",
       "spectrum",
     }, function(item)
@@ -32,9 +33,10 @@ M.create_filter_command = function()
     complete = function()
       return {
         "classic",
+        "light",
+        "machine",
         "octagon",
         "pro",
-        "machine",
         "ristretto",
         "spectrum",
       }

--- a/lua/monokai-pro/init.lua
+++ b/lua/monokai-pro/init.lua
@@ -10,7 +10,7 @@ M.load = function()
   util.theme.load(theme.setup())
 end
 
---- @param filter "classic" | "machine" | "octagon" | "pro" | "ristretto" | "spectrum"
+--- @param filter "light" | "classic" | "machine" | "octagon" | "pro" | "ristretto" | "spectrum"
 M._load = function(filter)
   config.extend({ filter = filter })
   M.load()


### PR DESCRIPTION
# Adding light theme as an option

Potential fix for my original request: #131

It looks like this:

<img width="426" alt="Screenshot 2024-11-29 at 18 01 49" src="https://github.com/user-attachments/assets/e13309a2-7908-4583-bd7e-c46358b08c06">

Which seams close enough to the reference to me:

<img width="513" alt="Screenshot 2024-11-29 at 18 04 52" src="https://github.com/user-attachments/assets/11be23d9-84ef-4258-a6cc-e058fd7efe53">

**Not done**

 - I've not made changes to the `readme` mainly because I'd not know how to keep the screenshots consistent.
 - I'm not sure what the `doc/tags` are used for so I left them as is.
 - The theme already has a `day` [filter](https://github.com/loctvl842/monokai-pro.nvim/blob/master/lua/monokai-pro/config.lua?plain=1#L24) which I'd originally expected to be this actual light theme. But for the sake of not breaking current setups I've not changed that. Maybe something to concider. 
