### PR TITLE
Make CursorColumn work correctly

### DIFF
--- a/lua/monokai-pro/theme/editor.lua
+++ b/lua/monokai-pro/theme/editor.lua
@@ -17,7 +17,7 @@ M.setup = function(c, config, hp)
     -- lCursor      = {}, -- the character under the cursor when |language-mapping| is used (see 'guicursor')
     -- CursorIM     = {bg = theme.palette.red}, -- like Cursor, but used when in IME mode |CursorIM|
     CursorColumn = {
-      bg = c.editor.background,
+      bg = c.editor.lineHighlightBackground,
     }, -- Screen-column at the cursor, when 'cursorcolumn' is set.
     CursorLine = {
       bg = c.editor.lineHighlightBackground,


### PR DESCRIPTION
This should fix https://github.com/loctvl842/monokai-pro.nvim/issues/14, https://github.com/loctvl842/monokai-pro.nvim/issues/16, https://github.com/loctvl842/monokai-pro.nvim/issues/23, and https://github.com/loctvl842/monokai-pro.nvim/issues/61. Some of those issues have workarounds in them, but most have downsides (`colors.base.dimmed5` is slightly different than `c.editor.lineHighlightBackground`.)

Those workarounds should no longer be necessary with this change.

CursorColumn can still be disabled by not setting it, or via `:lua vim.o.cursorcolumn = false`

Thank you for the colorscheme!