### PR TITLE
updated snacks highlighting to increase contrast on some unreadable text

### DIFF
--- a/lua/monokai-pro/theme/plugins/snacks.lua
+++ b/lua/monokai-pro/theme/plugins/snacks.lua
@@ -6,6 +6,18 @@ function M.get(c, _, hp)
     SnacksDashboardNormal = { bg = c.editor.background, fg = c.editor.foreground },
     SnacksDashboardDesc = { fg = c.base.dimmed1 },
     SnacksDashboardIcon = { fg = c.base.blue },
+    SnacksPickerDir = { fg = c.base.dimmed1 },
+    SnacksPickerFile = { fg = c.base.white },
+    SnacksWinKeySep = { fg = c.base.dimmed1 },
+    SnacksImageLoading = { fg = c.base.dimmed1 },
+    SnacksPickerTotals = { fg = c.base.dimmed1 },
+    SnacksPickerBufFlags = { fg = c.base.dimmed1 },
+    SnacksPickerKeymapRhs = { fg = c.base.dimmed1 },
+    SnacksPickerPathHidden = { fg = c.base.dimmed1 },
+    SnacksPickerUnselected = { fg = c.base.dimmed1 },
+    SnacksPickerPathIgnored = { fg = c.base.dimmed1 },
+    SnacksPickerGitStatusIngnored = { fg = c.base.dimmed1 },
+    SnacksPickerGitStatusUntracked = { fg = c.base.dimmed1 },
   }
 end
 


### PR DESCRIPTION
Some Snacks picker elements were too dark of text on a dark background. I went through the few highlight groups and brightened the text a bit using the existing palette so the text was readable.

I'm sure it could have been done in a more colorful way, but this works and is unobtrusive.

Before, notice the "SnacksPickerDir":

<img width="646" height="533" alt="image" src="https://github.com/user-attachments/assets/a389c45b-b16d-4267-a47e-c53f16f27631" />

<img width="646" height="533" alt="image" src="https://github.com/user-attachments/assets/2f7b6432-14d6-4485-9035-d9cfa3ca009e" />


After:

<img width="646" height="533" alt="image" src="https://github.com/user-attachments/assets/ea366ab0-a4e7-4fcb-9721-98813236dc44" />

<img width="1292" height="1066" alt="image" src="https://github.com/user-attachments/assets/62860b0f-a5b7-47e1-a70f-cf49abe48aec" />
