### PR TITLE
fix(snacks): dashboard dir and indent lines

### DIFF
--- a/lua/monokai-pro/theme/plugins/snacks.lua
+++ b/lua/monokai-pro/theme/plugins/snacks.lua
@@ -8,6 +8,7 @@ return {
     local highlights = {
       SnacksDashboardNormal  = { bg = c.editor.background, fg = c.editor.foreground },
       SnacksDashboardDesc    = { fg = c.base.dimmed1 },
+      SnacksDashboardDir     = { fg = c.base.dimmed2 },
       SnacksDashboardIcon    = { fg = c.base.blue },
       SnacksDashboardFooter  = { fg = c.base.green },
       SnacksDashboardHeader  = { fg = c.base.yellow },
@@ -27,7 +28,10 @@ return {
       SnacksPickerDir           = { fg = c.sideBar.foreground },
 
       -- Git
-      SnacksPickerGitStatusUntracked = { fg = c.gitDecoration.untrackedResourceForeground }
+      SnacksPickerGitStatusUntracked = { fg = c.gitDecoration.untrackedResourceForeground },
+
+      -- Indentation
+      SnacksIndent = { fg = c.editorIndentGuide.background },
     }
     local rainbow = {
       c.base.red,


### PR DESCRIPTION
This PR fixes 2 unreadable highlight groups for [snacks.nvim](https://github.com/folke/snacks.nvim)

| Highlight group | Before | After |
| -- | -- | -- |
| `SnacksDashboardDir` | <img width="755" height="715" alt="image" src="https://github.com/user-attachments/assets/34996667-7c53-4233-ac40-ed820b553281" /> | <img width="922" height="700" alt="image" src="https://github.com/user-attachments/assets/98ea5d00-17c6-4dcd-b3c7-e3cbc7ed02e6" />
| `SnacksIndent` | <img width="798" height="302" alt="image" src="https://github.com/user-attachments/assets/1407450a-a736-4d6b-be3c-9ec79c8b50df" /> | <img width="777" height="311" alt="image" src="https://github.com/user-attachments/assets/3ace9775-3ca4-49b9-b300-d66885925915" />

