### PR TITLE
Refactor ~/plugins/rainbow-delimiters.lua to better match colorscheme

### DIFF
--- a/lua/monokai-pro/theme/plugins/rainbow-delimiters.lua
+++ b/lua/monokai-pro/theme/plugins/rainbow-delimiters.lua
@@ -6,12 +6,11 @@ return {
   highlights = function(c)
     return {
       RainbowDelimiterRed = { fg = c.base.red },
-      RainbowDelimiterYellow = { fg = c.base.yellow },
-      RainbowDelimiterBlue = { fg = c.base.cyan },
       RainbowDelimiterOrange = { fg = c.base.blue },
+      RainbowDelimiterYellow = { fg = c.base.yellow },
       RainbowDelimiterGreen = { fg = c.base.green },
-      RainbowDelimiterViolet = { fg = c.base.magenta },
       RainbowDelimiterCyan = { fg = c.base.cyan },
+      RainbowDelimiterViolet = { fg = c.base.magenta },
     }
   end,
 }


### PR DESCRIPTION
Reordered rainbow-delimiters plugin to go

red -> orange -> yellow -> green -> cyan -> violet -> red

to better match color scheme and improve readability.

<img width="491" height="233" alt="image" src="https://github.com/user-attachments/assets/9d43d1d8-3dec-4261-bd23-e787aeaffa0f" />
