### PR TITLE
fix: unify backgrounds and fix visibility for snacks explorer

### DIFF
--- a/lua/monokai-pro/theme/plugins/snacks.lua
+++ b/lua/monokai-pro/theme/plugins/snacks.lua
@@ -19,6 +19,9 @@ return {
       SnacksPickerTree = { bg = c.sideBar.background, fg = c.editorIndentGuide.background },
 
       -- Picker
+      SnacksPicker              = { bg = c.sideBar.background, fg = c.sideBar.foreground },
+      SnacksPickerList          = { bg = c.sideBar.background, fg = c.sideBar.foreground },
+      SnacksPickerMatch         = { fg = c.base.yellow, bold = true },
       SnacksPickerInputBorder   = { bg = c.sideBar.background, fg = c.sideBar.foreground },
       SnacksPickerTitle         = { bg = c.sideBar.background, fg = c.base.yellow, bold = true },
       SnacksPickerPrompt        = { bg = c.sideBar.background, fg = c.base.blue },
@@ -27,7 +30,7 @@ return {
       SnacksPickerDir           = { fg = c.sideBar.foreground },
 
       -- Git
-      SnacksPickerGitStatusUntracked = { fg = c.gitDecoration.untrackedResourceForeground }
+      SnacksPickerGitStatusUntracked = { fg = c.gitDecoration.untrackedResourceForeground },
     }
     local rainbow = {
       c.base.red,


### PR DESCRIPTION
Added the missing highlight groups for snacks, specifically focusing on the new Picker and Explorer modules.

|Before|After|
|---|---|
|<img width="1131" height="912" alt="image" src="https://github.com/user-attachments/assets/f5a8cd7b-2cb4-4d58-ad96-006b3d6f123f" />|<img width="1358" height="667" alt="image" src="https://github.com/user-attachments/assets/57591252-77d9-4e1a-a085-c1db4012ca0e" />|
|<img width="1131" height="912" alt="image" src="https://github.com/user-attachments/assets/27e5859c-b1c7-4217-9be2-e425d3988826" />|<img width="1354" height="666" alt="image" src="https://github.com/user-attachments/assets/3c0754ad-33e7-449b-b2ea-b0131f249c11" />|